### PR TITLE
Add example of Float / Int confusion when type signature is present

### DIFF
--- a/type-definition-mismatch.elm
+++ b/type-definition-mismatch.elm
@@ -1,0 +1,9 @@
+import Graphics.Collage exposing (..)
+
+ngon2 : Float -> Int -> Shape
+ngon2 f r =
+  let
+    n = truncate f
+  in
+    ngon n r
+


### PR DESCRIPTION
In this example, Elm has a conflict between Int and Float. However,
the type signature contains an Int and a Float. Based on the
error message below, I can not understand what Elm thinks
is the definition and which Float or Int is incorrect.

The type annotation for `ngon2` does not match its definition.

3| ngon2 : Float -> Int -> Shape
As I infer the type of values flowing through your program, I see a conflict
between these two types:

```
Int

Float
```
