### PR TITLE
Add example of duplicate top-level definition.

### DIFF
--- a/naming/duplicate-definition.elm
+++ b/naming/duplicate-definition.elm
@@ -1,0 +1,5 @@
+value : Int
+value = 0
+
+value : Int
+value = 1


### PR DESCRIPTION
The error message should indicate the lines of all the definitions.
