### PR TITLE
Added example for the type checker blowing up in the wrong place

### DIFF
--- a/types/if-check-inside-case.elm
+++ b/types/if-check-inside-case.elm
@@ -1,0 +1,23 @@
+type alias Model =
+  { field : Maybe String
+  }
+
+type Action
+  = MouseEnter
+  | MouseMove
+
+update : Action -> Model -> Model
+update action model =
+  case action of
+    MouseEnter ->
+      if model.field == Just 3 then
+        { model | field <- Just 0
+                }
+      else
+        model
+    MouseMove ->
+      if model.field == Just "string"
+      then
+        model
+      else
+        model


### PR DESCRIPTION
The error complains about 'type mismatch' inside
'if model.field == Just "string"', instead of in '{ model | field <- 0 }' or the
first if. The type of 'model' is annotated to Maybe String.
