### PR TITLE
A hint for this error would probably have saved me time.

### DIFF
--- a/types/not-record-accessed-as-one.elm
+++ b/types/not-record-accessed-as-one.elm
@@ -1,0 +1,4 @@
+
+
+do : List String -> Int
+do list = list.length * 5


### PR DESCRIPTION
A hint like "Are you accessing something that is not a record type as a record".
The classic example is are you doing "myVar.length" when you should be doing "List.length myVar"

I've been doing quite a lot of Elm the last few weeks, and this error in a more complex scenario swallowed well over an hour because I did not have the right experience for it yet. The next time I hit this I am sure it will be minutes to solve. 

I think it would have helped me a lot to give a hint to the error message as you do very usefully in many other errors.
