### PR TITLE
Remove rigid supers example because it compiles now

### DIFF
--- a/types/type-annotation-rigid-supers.elm
+++ b/types/type-annotation-rigid-supers.elm
@@ -1,9 +1,0 @@
--- https://github.com/elm-lang/elm-compiler/issues/821
-
-comparePair : comparable -> comparable -> comparable1 -> comparable2 -> Bool
-comparePair a b x y =
-  a < b || x < y
-
-
-usage =
-  comparePair 1 2 "hi" "blah"


### PR DESCRIPTION
I just tried to compile all the examples to see the error messages. Turns out that this one compiles now. So there is no point having it in this catalog anymore.
