### PR TITLE
Confusing error message on unbalanced square brackets

### DIFF
--- a/syntax/unmatched-brackets.elm
+++ b/syntax/unmatched-brackets.elm
@@ -1,0 +1,10 @@
+pairs =
+  [ ["value-1"
+    , "value-2"]
+
+  , ["value-3"
+    , "value-4"
+  ]
+
+symbol : String
+symbol = "hello world"


### PR DESCRIPTION
Hello there,

As part of my pitch of Elm to the company I work for, I was trying to show how good compiler error messages were. Sadly I found one of those trivial scenarios where this is not the case:

Input:

``` elm
pairs =
  [ ["value-1"
    , "value-2"]

  , ["value-3"
    , "value-4"
  ]

symbol : String
symbol = "hello world"
```

Given Error:

```
-- SYNTAX PROBLEM --------------------------------------- unmatched-brackets.elm

I need whitespace, but got stuck on what looks like a new declaration. You are
either missing some stuff in the declaration above or just need to add some
spaces here:

9│ symbol : String
   ^
I am looking for one of the following things:

    whitespace

Detected errors in 1 module.
```

Expected Error:

```
-- SYNTAX PROBLEM --------------------------------------- unmatched-brackets.elm

I ran into something unexpected when parsing your code!

9│ symbol : String
   ^
I am looking for one of the following things:

    a closing square bracket ']'
    whitespace

Detected errors in 1 module.
```
