### PR TITLE
Create keywords.elm

### DIFF
--- a/naming/keywords.elm
+++ b/naming/keywords.elm
@@ -1,0 +1,7 @@
+import Html exposing (text)
+
+main =
+  let (x, y, _) = List.foldL (\elem (sum, diff, mult) ->
+      (sum + elem, elem - diff, mult * elem)
+    ) (0, 0, 0) [1, 2, 3, 4, 5] in
+  text ("Hello, World!" ++ toString x)


### PR DESCRIPTION
This file raises the parsing error:
Detected errors in 1 module.
-- SYNTAX PROBLEM ------------------------------------------------------------

It looks like the keyword in is being used as a variable.

7| ) (0, 0, 0) [1, 2, 3, 4, 5] in
                                        ^
Rename it to something else.