### PR TITLE
Added example querying an unbound type variable

### DIFF
--- a/naming/typo-not-unbound.elm
+++ b/naming/typo-not-unbound.elm
@@ -1,0 +1,2 @@
+type alias Counter =
+  { i : int }


### PR DESCRIPTION
The error message says:

    -- UNBOUND TYPE VARIABLE ---------------------------------- typo-not-unbound.elm

    The `Counter` type alias uses an unbound type variable `int` in its definition:

    1| type alias Counter =
    2|   { i : int }
               ^^^
    You probably need to change the declaration to something like this:

        type alias Counter int = ...

Maybe it is an unbound type variable. But maybe I just made a typo and should have used a
capital letter.

This won't just happen with builtin types, of course. In my own application
I defined my own type called `Column` and got the above error when I mistyped it as `column`.
